### PR TITLE
[platform][app-arch] - idle workers for multiple queues

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -281,8 +281,13 @@ func DeepCopyItem(original map[string]QueueSpec) map[string]QueueSpec {
 }
 
 func Aggregate(qSpecs map[string]QueueSpec) (int32, float64, int32) {
-	var totalMessages int32
-	var totalMessagesSentPerMinute float64
+	totalMessages := int32(0)
+	totalMessagesSentPerMinute := float64(0)
+
+	if len(qSpecs) == 0 {
+		return totalMessages, totalMessagesSentPerMinute, UnsyncedIdleWorkers
+	}
+
 	for _, qSpec := range qSpecs {
 		totalMessages += qSpec.Messages
 		totalMessagesSentPerMinute += qSpec.MessagesSentPerMinute


### PR DESCRIPTION
__Why is this change needed?__
Test Case:
- k8s deployment that processes 2 queues
- 1 queue has no traffic
- 2nd queues has enqueue rate of n msgs/sec

Result: 
- Deployment is being scaled down as idle workers is currently set to be the max for all queues.

__How does the PR address the problem?__
Instead, idle workers is set to be the min of all queues. Note that -1 is a special value.

__What else do I need to know?__
Tested on preview.