### PR TITLE
[platform][app-arch] - add environment label to prometheus metrics

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -168,7 +168,7 @@ func TestGetDesiredWorkersMultiQueue(t *testing.T) {
 	disruption := "20%"
 	currentWorkers, minWorkers, maxWorkers := int32(5), int32(0), int32(10)
 	desiredWorkers, totalQueueMessages, idleWorkers := controller.GetDesiredWorkersMultiQueue(
-		"", "", "", qSpecs, k8QSpecs, currentWorkers, minWorkers, maxWorkers, &disruption)
+		"", "", "", "test", qSpecs, k8QSpecs, currentWorkers, minWorkers, maxWorkers, &disruption)
 	if desiredWorkers != 0 && totalQueueMessages != 0 && idleWorkers != currentWorkers {
 		t.Errorf("expected all workers to be idle as there are no active queues")
 	}


### PR DESCRIPTION
**Why is this change needed?**
Currently, if multiple deployments of wpa are running on the same k8s cluster, it is not possible to differentiate metrics.

**How does the PR address the problem?**
Adds new label to all metrics called `env`.

**What else do I need to know?**
https://k2labs.atlassian.net/browse/MIG-4698