### PR TITLE
[platform][app-arch] - fix bug when filtering active queues

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -260,7 +260,7 @@ func (q *Queues) ListActiveMultiQueues(key string) map[string]QueueSpec {
 	specs := make(map[string]QueueSpec)
 	for k, v := range items {
 		queueName := GetQueueName(v.uri)
-		if !config.GetBool(queueName, false) && strings.HasPrefix(k, key) && v.Messages > 0 {
+		if !config.GetBool(queueName, false) && strings.HasPrefix(k, key) {
 			specs[v.uri] = v
 		}
 	}


### PR DESCRIPTION
**Why is this change needed?**
Additional condition is prematurely filtering out active queues based on available + unavailable messages.

**How does the PR address the problem?**
Removes the condition.

**What else do I need to know?**
https://k2labs.atlassian.net/browse/MIG-4698