### PR TITLE
[platform][app-arch] - cleanup resources on spec updates

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -428,7 +428,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		}
 	case WokerPodAutoScalerEventUpdate:
 		// Delete any queues that are no longer part of the spec
-		for _, uri := range queue.MinusSet(c.Queues.ListMultiQueues(key), workerPodAutoScaler.Spec.Queues) {
+		for _, uri := range queue.LeftDifference(c.Queues.ListMultiQueues(key), workerPodAutoScaler.Spec.Queues) {
 			c.Queues.Delete(namespace, name, uri)
 		}
 		// Update/add queues based on the spec

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -427,6 +427,11 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 			)
 		}
 	case WokerPodAutoScalerEventUpdate:
+		// Delete any queues that are no longer part of the spec
+		for _, uri := range queue.MinusSet(c.Queues.ListMultiQueues(key), workerPodAutoScaler.Spec.Queues) {
+			c.Queues.Delete(namespace, name, uri)
+		}
+		// Update/add queues based on the spec
 		for _, q := range workerPodAutoScaler.Spec.Queues {
 			err = c.Queues.Add(
 				namespace,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -429,7 +429,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 	case WokerPodAutoScalerEventUpdate:
 		// Delete any queues that are no longer part of the spec
 		for _, uri := range queue.LeftDifference(c.Queues.ListMultiQueues(key), workerPodAutoScaler.Spec.Queues) {
-			c.Queues.Delete(namespace, name, uri)
+			c.Queues.Delete(namespace, name, queue.GetQueueName(uri))
 		}
 		// Update/add queues based on the spec
 		for _, q := range workerPodAutoScaler.Spec.Queues {

--- a/pkg/queue/utils.go
+++ b/pkg/queue/utils.go
@@ -1,0 +1,22 @@
+package queue
+
+import (
+	v1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscalermultiqueue/v1"
+)
+
+// MinusSet returns the elements of x that are not in y
+func MinusSet(x map[string]QueueSpec, y []v1.Queue) []string {
+	yMap := make(map[string]bool)
+	for _, q := range y {
+		yMap[q.URI] = true
+	}
+
+	result := make([]string, 0)
+	for uri, _ := range x {
+		if _, ok := yMap[uri]; !ok {
+			result = append(result, uri)
+		}
+	}
+
+	return result
+}

--- a/pkg/queue/utils.go
+++ b/pkg/queue/utils.go
@@ -4,8 +4,8 @@ import (
 	v1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscalermultiqueue/v1"
 )
 
-// MinusSet returns the elements of x that are not in y
-func MinusSet(x map[string]QueueSpec, y []v1.Queue) []string {
+// LeftDifference returns the elements of x that are not in y
+func LeftDifference(x map[string]QueueSpec, y []v1.Queue) []string {
 	yMap := make(map[string]bool)
 	for _, q := range y {
 		yMap[q.URI] = true

--- a/pkg/queue/utils_test.go
+++ b/pkg/queue/utils_test.go
@@ -63,14 +63,14 @@ func TestMinusSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MinusSet(tt.x, tt.y)
+			result := LeftDifference(tt.x, tt.y)
 			if len(result) != len(tt.expected) {
-				t.Errorf("MinusSet() = %v, expected %v", result, tt.expected)
+				t.Errorf("LeftDifference() = %v, expected %v", result, tt.expected)
 				return
 			}
 			for i := 0; i < len(result); i++ {
 				if result[i] != tt.expected[i] {
-					t.Errorf("MinusSet() = %v, expected %v", result, tt.expected)
+					t.Errorf("LeftDifference() = %v, expected %v", result, tt.expected)
 				}
 			}
 		})

--- a/pkg/queue/utils_test.go
+++ b/pkg/queue/utils_test.go
@@ -1,0 +1,78 @@
+package queue
+
+import (
+	v1 "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscalermultiqueue/v1"
+	"testing"
+)
+
+func TestMinusSet(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		name     string
+		x        map[string]QueueSpec
+		y        []v1.Queue
+		expected []string
+	}{
+		{
+			name: "missing x element in y",
+			x: map[string]QueueSpec{
+				"queue1": {
+					uri: "queue1",
+				},
+				"queue2": {
+					uri: "queue2",
+				},
+				"queue3": {
+					uri: "queue3",
+				},
+			},
+			y: []v1.Queue{
+				{
+					URI: "queue1",
+				},
+				{
+					URI: "queue2",
+				},
+			},
+			expected: []string{"queue3"},
+		},
+		{
+			name: "empty set x",
+			x:    map[string]QueueSpec{},
+			y: []v1.Queue{
+				{
+					URI: "queue1",
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "empty set y",
+			x: map[string]QueueSpec{
+				"queue1": {
+					uri: "queue1",
+				},
+				"queue2": {
+					uri: "queue2",
+				},
+			},
+			y:        []v1.Queue{},
+			expected: []string{"queue1", "queue2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MinusSet(tt.x, tt.y)
+			if len(result) != len(tt.expected) {
+				t.Errorf("MinusSet() = %v, expected %v", result, tt.expected)
+				return
+			}
+			for i := 0; i < len(result); i++ {
+				if result[i] != tt.expected[i] {
+					t.Errorf("MinusSet() = %v, expected %v", result, tt.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Why is this change needed?**
When wpa-multiqueue manifest is updated, the poller resources are not always cleaned up.

**How does the PR address the problem?**
When updates are made to the SQS queue, irrelevant poller threads are pruned.

**What else do I need to know?**
Validated fix on preview by:
- creating a WPA-multiqueue spec with invalid URI
- validating poller errors
- updating to valid URI
- validating poller errors are resolved

https://k2labs.atlassian.net/browse/MIG-4604