### PR TITLE
Add concurrency factor to modify scaling logic when concurrency is in place

### DIFF
--- a/artifacts/crd.yaml
+++ b/artifacts/crd.yaml
@@ -52,6 +52,11 @@ spec:
                 type: integer
                 format: int32
                 description: 'Minimum number of workers you want to run'
+              concurrency:
+                type: integer
+                format: int32
+                default: 1
+                description: 'Number of concurrent jobs that can be processed by a worker.'
               queues:
                 type: array
                 items:

--- a/pkg/apis/workerpodautoscalermultiqueue/v1/types.go
+++ b/pkg/apis/workerpodautoscalermultiqueue/v1/types.go
@@ -22,6 +22,7 @@ type WorkerPodAutoScalerMultiQueueSpec struct {
 	MaxReplicas    *int32  `json:"maxReplicas"`
 	MaxDisruption  *string `json:"maxDisruption,omitempty"`
 	DeploymentName string  `json:"deploymentName,omitempty"`
+	Concurrency    *int32  `json:"concurrency,omitempty"`
 	Queues         []Queue `json:"queues,omitempty"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -686,8 +686,7 @@ func getMinMultiQueueWorkers(
 	deploymentName string,
 	queueSpecs map[string]queue.QueueSpec,
 	minWorkers int32,
-	concurrency int32,
-) int32 {
+	concurrency int32) int32 {
 	var totalMinWorkers int32
 	var totalWorkersBasedOnMessagesSent float64
 	for _, qSpec := range queueSpecs {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -469,7 +469,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 	}
 
 	concurrency := int32(1)
-	if workerPodAutoScaler.Spec.Concurrency != nil {
+	if workerPodAutoScaler.Spec.Concurrency != nil && *workerPodAutoScaler.Spec.Concurrency > 0 {
 		concurrency = *workerPodAutoScaler.Spec.Concurrency
 	}
 	desiredWorkers, totalQueueMessages, idleWorkers := GetDesiredWorkersMultiQueue(
@@ -663,8 +663,7 @@ func getMinWorkers(
 	messagesSentPerMinute float64,
 	minWorkers int32,
 	secondsToProcessOneJob float64,
-	concurrency int32,
-) int32 {
+	concurrency int32) int32 {
 
 	// disable this feature for WPA queues which have not specified
 	// processing time
@@ -722,8 +721,7 @@ func GetDesiredWorkers(
 	minWorkers int32,
 	maxWorkers int32,
 	maxDisruption *string,
-	concurrency int32,
-) int32 {
+	concurrency int32) int32 {
 
 	logger.Debug().Msgf("%s min=%v, max=%v, targetBacklog=%v \n",
 		queueName, minWorkers, maxWorkers, targetMessagesPerWorker)
@@ -842,8 +840,7 @@ func GetDesiredWorkersMultiQueue(
 	minWorkers int32,
 	maxWorkers int32,
 	maxDisruption *string,
-	concurrency int32, // new parameter
-) (int32, int32, int32) {
+	concurrency int32) (int32, int32, int32) {
 	var totalQueueMessages int32
 	var totalMessagesSentPerMinute float64
 	var idleWorkers int32

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -468,6 +468,10 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		}
 	}
 
+	concurrency := int32(1)
+	if workerPodAutoScaler.Spec.Concurrency != nil {
+		concurrency = *workerPodAutoScaler.Spec.Concurrency
+	}
 	desiredWorkers, totalQueueMessages, idleWorkers := GetDesiredWorkersMultiQueue(
 		c.logger,
 		name,
@@ -480,7 +484,9 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		*workerPodAutoScaler.Spec.MinReplicas,
 		*workerPodAutoScaler.Spec.MaxReplicas,
 		workerPodAutoScaler.GetMaxDisruption(c.defaultMaxDisruption),
+		concurrency,
 	)
+
 	// set metrics
 	for _, qSpec := range qSpecs {
 		qMsgs.WithLabelValues(
@@ -656,7 +662,9 @@ func getMinWorkers(
 	logger zerolog.Logger,
 	messagesSentPerMinute float64,
 	minWorkers int32,
-	secondsToProcessOneJob float64) int32 {
+	secondsToProcessOneJob float64,
+	concurrency int32,
+) int32 {
 
 	// disable this feature for WPA queues which have not specified
 	// processing time
@@ -664,7 +672,7 @@ func getMinWorkers(
 		return minWorkers
 	}
 
-	workersBasedOnMessagesSent := int32(math.Ceil((secondsToProcessOneJob * messagesSentPerMinute) / 60))
+	workersBasedOnMessagesSent := int32(math.Ceil((secondsToProcessOneJob * messagesSentPerMinute) / (60 * float64(concurrency))))
 	logger.Debug().Msgf("%v, workersBasedOnMessagesSent=%v\n", secondsToProcessOneJob, workersBasedOnMessagesSent)
 	if workersBasedOnMessagesSent > minWorkers {
 		return workersBasedOnMessagesSent
@@ -678,11 +686,13 @@ func getMinMultiQueueWorkers(
 	logger zerolog.Logger,
 	deploymentName string,
 	queueSpecs map[string]queue.QueueSpec,
-	minWorkers int32) int32 {
+	minWorkers int32,
+	concurrency int32,
+) int32 {
 	var totalMinWorkers int32
 	var totalWorkersBasedOnMessagesSent float64
 	for _, qSpec := range queueSpecs {
-		workersBasedOnMessagesSent := (qSpec.SecondsToProcessOneJob * qSpec.MessagesSentPerMinute) / 60
+		workersBasedOnMessagesSent := (qSpec.SecondsToProcessOneJob * qSpec.MessagesSentPerMinute) / (60 * float64(concurrency))
 		totalWorkersBasedOnMessagesSent += workersBasedOnMessagesSent
 		logger.Debug().Msgf("%s: secondsToProcessOneJob=%v, workersBasedOnMessagesSent=%v\n", qSpec.Name, qSpec.SecondsToProcessOneJob, workersBasedOnMessagesSent)
 	}
@@ -711,7 +721,9 @@ func GetDesiredWorkers(
 	idleWorkers int32,
 	minWorkers int32,
 	maxWorkers int32,
-	maxDisruption *string) int32 {
+	maxDisruption *string,
+	concurrency int32,
+) int32 {
 
 	logger.Debug().Msgf("%s min=%v, max=%v, targetBacklog=%v \n",
 		queueName, minWorkers, maxWorkers, targetMessagesPerWorker)
@@ -724,6 +736,7 @@ func GetDesiredWorkers(
 		messagesSentPerMinute,
 		minWorkers,
 		secondsToProcessOneJob,
+		concurrency,
 	)
 
 	// gets the maximum number of workers that can be scaled down in a
@@ -828,16 +841,22 @@ func GetDesiredWorkersMultiQueue(
 	currentWorkers int32,
 	minWorkers int32,
 	maxWorkers int32,
-	maxDisruption *string) (int32, int32, int32) {
+	maxDisruption *string,
+	concurrency int32, // new parameter
+) (int32, int32, int32) {
 	var totalQueueMessages int32
 	var totalMessagesSentPerMinute float64
 	var idleWorkers int32
 
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
 	for _, k8QSpec := range k8QueueSpecs {
 		if qSpec, ok := queueSpecs[k8QSpec.URI]; ok {
 			targetMessagesPerWorker := float64(k8QSpec.SLA) / qSpec.SecondsToProcessOneJob
-			logger.Debug().Msgf("%s min=%v, max=%v, targetMessagesPerWorker=%v \n",
-				qSpec.Name, minWorkers, maxWorkers, targetMessagesPerWorker)
+			logger.Debug().Msgf("%s min=%v, max=%v, targetMessagesPerWorker=%v, concurrency=%v \n",
+				qSpec.Name, minWorkers, maxWorkers, targetMessagesPerWorker, concurrency)
 		}
 	}
 
@@ -856,6 +875,7 @@ func GetDesiredWorkersMultiQueue(
 		deploymentName,
 		queueSpecs,
 		minWorkers,
+		concurrency,
 	)
 
 	workersMinInternal.WithLabelValues(
@@ -877,7 +897,8 @@ func GetDesiredWorkersMultiQueue(
 	for _, k8QSpec := range k8QueueSpecs {
 		if qSpec, ok := queueSpecs[k8QSpec.URI]; ok {
 			targetMessagesPerWorker := float64(k8QSpec.SLA) / qSpec.SecondsToProcessOneJob
-			approxDesiredWorkers += float64(qSpec.Messages) / targetMessagesPerWorker
+			// Multiply queue throughput by concurrency for each queue
+			approxDesiredWorkers += float64(qSpec.Messages) / (targetMessagesPerWorker * float64(concurrency))
 		}
 	}
 	desiredWorkers = int32(math.Ceil(approxDesiredWorkers))
@@ -887,7 +908,7 @@ func GetDesiredWorkersMultiQueue(
 		deploymentName,
 		env,
 	).Set(float64(desiredWorkers))
-	logger.Debug().Msgf("MinWorkers: %v, MaxWorkers: %v, DesiredWorkers: %v, CurrentWorkers: %v, idleWorkers=%v\n", minWorkers, maxWorkers, desiredWorkers, currentWorkers, idleWorkers)
+	logger.Debug().Msgf("MinWorkers: %v, MaxWorkers: %v, DesiredWorkers: %v, CurrentWorkers: %v, idleWorkers=%v, Concurrency=%v\n", minWorkers, maxWorkers, desiredWorkers, currentWorkers, idleWorkers, concurrency)
 
 	if currentWorkers == 0 {
 		return convertDesiredReplicasWithRules(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -844,10 +844,6 @@ func GetDesiredWorkersMultiQueue(
 	var totalMessagesSentPerMinute float64
 	var idleWorkers int32
 
-	if concurrency < 1 {
-		concurrency = 1
-	}
-
 	for _, k8QSpec := range k8QueueSpecs {
 		if qSpec, ok := queueSpecs[k8QSpec.URI]; ok {
 			targetMessagesPerWorker := float64(k8QSpec.SLA) / qSpec.SecondsToProcessOneJob

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -21,6 +21,7 @@ type desiredWorkerTester struct {
 	minWorkers              int32
 	maxWorkers              int32
 	maxDisruption           string
+	concurrency             int32
 }
 
 func (c *desiredWorkerTester) getDesired() int32 {
@@ -37,6 +38,7 @@ func (c *desiredWorkerTester) getDesired() int32 {
 		c.minWorkers,
 		c.maxWorkers,
 		&c.maxDisruption,
+		c.concurrency,
 	)
 }
 
@@ -62,6 +64,7 @@ func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
 		minWorkers:              0,
 		maxWorkers:              20,
 		maxDisruption:           "10%",
+		concurrency:             1,
 	}
 
 	c.test(t, 18)
@@ -82,6 +85,7 @@ func TestScaleUpWhenCalculatedMinIsGreaterThanMax(t *testing.T) {
 		minWorkers:              2,
 		maxWorkers:              20,
 		maxDisruption:           "0%",
+		concurrency:             1,
 	}
 
 	c.test(t, 20)
@@ -101,6 +105,7 @@ func TestScaleForLongRunningWorkersTakingMinutesToProcess(t *testing.T) {
 		minWorkers:              0,
 		maxWorkers:              500,
 		maxDisruption:           "0%", // partial scale down is not allowed
+		concurrency:             1,
 	}
 
 	// first loop should returns 10 desired workers
@@ -139,6 +144,7 @@ func TestTargetScalingForLongRunningWorkers(t *testing.T) {
 		minWorkers:              0,
 		maxWorkers:              100,
 		maxDisruption:           "100%",
+		concurrency:             1,
 	}
 
 	c.test(t, 2)
@@ -160,6 +166,7 @@ func TestRPMScalingForFastRunningWorkers(t *testing.T) {
 		minWorkers:              0,
 		maxWorkers:              100,
 		maxDisruption:           "100%",
+		concurrency:             1,
 	}
 
 	c.test(t, 2)
@@ -170,8 +177,9 @@ func TestGetDesiredWorkersMultiQueue(t *testing.T) {
 	var k8QSpecs []v1.Queue
 	disruption := "20%"
 	currentWorkers, minWorkers, maxWorkers := int32(5), int32(0), int32(10)
+	concurrency := int32(1)
 	desiredWorkers, totalQueueMessages, idleWorkers := controller.GetDesiredWorkersMultiQueue(
-		zerolog.Nop(), "", "", "", "test", qSpecs, k8QSpecs, currentWorkers, minWorkers, maxWorkers, &disruption)
+		zerolog.Nop(), "", "", "", "test", qSpecs, k8QSpecs, currentWorkers, minWorkers, maxWorkers, &disruption, concurrency)
 	if desiredWorkers != 0 && totalQueueMessages != 0 && idleWorkers != currentWorkers {
 		t.Errorf("expected all workers to be idle as there are no active queues")
 	}


### PR DESCRIPTION
Add concurrency factor and modified scaling logic 
- Defined concurrency in OpenAPISchema
- Used the variable to adjust autoscaling logic

JIRA: https://k2labs.atlassian.net/browse/MIG-6607