### PR TITLE
Add concurrencyScalingRatio variable to wpa

### DIFF
--- a/artifacts/crd.yaml
+++ b/artifacts/crd.yaml
@@ -61,7 +61,7 @@ spec:
                 type: number
                 format: float
                 default: 1.0
-                description: 'Ratio of concurrency to scale up/down the workers. For example, if concurrency is 2 and concurrencyScalingRatio is 0.8, then the worker will scale down by 1.6 (2 * 0.8).'
+                description: 'Number to reduce the scale down of replicas with concurrency. For example, if concurrency is 2 and concurrencyScalingRatio is 0.8, then the worker will scale down by 1.6 (2 * 0.8), instead of 2.'
               queues:
                 type: array
                 items:

--- a/artifacts/crd.yaml
+++ b/artifacts/crd.yaml
@@ -57,6 +57,11 @@ spec:
                 format: int32
                 default: 1
                 description: 'Number of concurrent jobs that can be processed by a worker.'
+              concurrencyScalingRatio:
+                type: number
+                format: float
+                default: 1.0
+                description: 'Ratio of concurrency to scale up/down the workers. For example, if concurrency is 2 and concurrencyScalingRatio is 0.8, then the worker will scale down by 1.6 (2 * 0.8).'
               queues:
                 type: array
                 items:

--- a/pkg/apis/workerpodautoscalermultiqueue/v1/types.go
+++ b/pkg/apis/workerpodautoscalermultiqueue/v1/types.go
@@ -18,12 +18,13 @@ type WorkerPodAutoScalerMultiQueue struct {
 
 // WorkerPodAutoScalerMultiQueueSpec is the spec for a WorkerPodAutoScalerMultiQueue resource
 type WorkerPodAutoScalerMultiQueueSpec struct {
-	MinReplicas    *int32  `json:"minReplicas"`
-	MaxReplicas    *int32  `json:"maxReplicas"`
-	MaxDisruption  *string `json:"maxDisruption,omitempty"`
-	DeploymentName string  `json:"deploymentName,omitempty"`
-	Concurrency    *int32  `json:"concurrency,omitempty"`
-	Queues         []Queue `json:"queues,omitempty"`
+	MinReplicas             *int32  `json:"minReplicas"`
+	MaxReplicas             *int32  `json:"maxReplicas"`
+	MaxDisruption           *string `json:"maxDisruption,omitempty"`
+	DeploymentName          string  `json:"deploymentName,omitempty"`
+	Concurrency             *int32  `json:"concurrency,omitempty"`
+	ConcurrencyScalingRatio *float64 `json:"concurrencyScalingRatio,omitempty"`
+	Queues                  []Queue `json:"queues,omitempty"`
 }
 
 type Queue struct {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -22,6 +22,7 @@ type desiredWorkerTester struct {
 	maxWorkers              int32
 	maxDisruption           string
 	concurrency             int32
+	concurrencyScalingRatio float64
 }
 
 func (c *desiredWorkerTester) getDesired() int32 {
@@ -39,6 +40,7 @@ func (c *desiredWorkerTester) getDesired() int32 {
 		c.maxWorkers,
 		&c.maxDisruption,
 		c.concurrency,
+		c.concurrencyScalingRatio,
 	)
 }
 
@@ -65,6 +67,7 @@ func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
 		maxWorkers:              20,
 		maxDisruption:           "10%",
 		concurrency:             1,
+		concurrencyScalingRatio: 1.0,
 	}
 
 	c.test(t, 18)
@@ -86,6 +89,7 @@ func TestScaleUpWhenCalculatedMinIsGreaterThanMax(t *testing.T) {
 		maxWorkers:              20,
 		maxDisruption:           "0%",
 		concurrency:             1,
+		concurrencyScalingRatio: 1.0,
 	}
 
 	c.test(t, 20)
@@ -106,6 +110,7 @@ func TestScaleForLongRunningWorkersTakingMinutesToProcess(t *testing.T) {
 		maxWorkers:              500,
 		maxDisruption:           "0%", // partial scale down is not allowed
 		concurrency:             1,
+		concurrencyScalingRatio: 1.0,
 	}
 
 	// first loop should returns 10 desired workers
@@ -145,6 +150,7 @@ func TestTargetScalingForLongRunningWorkers(t *testing.T) {
 		maxWorkers:              100,
 		maxDisruption:           "100%",
 		concurrency:             1,
+		concurrencyScalingRatio: 1.0,
 	}
 
 	c.test(t, 2)
@@ -167,6 +173,7 @@ func TestRPMScalingForFastRunningWorkers(t *testing.T) {
 		maxWorkers:              100,
 		maxDisruption:           "100%",
 		concurrency:             1,
+		concurrencyScalingRatio: 1.0,
 	}
 
 	c.test(t, 2)
@@ -178,8 +185,9 @@ func TestGetDesiredWorkersMultiQueue(t *testing.T) {
 	disruption := "20%"
 	currentWorkers, minWorkers, maxWorkers := int32(5), int32(0), int32(10)
 	concurrency := int32(1)
+	concurrencyScalingRatio := float64(1)
 	desiredWorkers, totalQueueMessages, idleWorkers := controller.GetDesiredWorkersMultiQueue(
-		zerolog.Nop(), "", "", "", "test", qSpecs, k8QSpecs, currentWorkers, minWorkers, maxWorkers, &disruption, concurrency)
+		zerolog.Nop(), "", "", "", "test", qSpecs, k8QSpecs, currentWorkers, minWorkers, maxWorkers, &disruption, concurrency, concurrencyScalingRatio)
 	if desiredWorkers != 0 && totalQueueMessages != 0 && idleWorkers != currentWorkers {
 		t.Errorf("expected all workers to be idle as there are no active queues")
 	}


### PR DESCRIPTION
**Why is this change needed?** 

- There is already a concurrency paramater defined in WPA to account for autoscaling WPA logic.
- Adding another parameter, concurrencyScalingRatio in WPA logic
- Current logic holds that with concurrency X, we will expect a throughput gain of X per replica.
- This is not always the case, hence we are introducing another variable that ensures a safe buffer of scaling. For example, with concurrencyScalingRatio of 0.8, we are essentially saying that we will expect atleast X * 0.8 throughput gain with concurrency X.
- The default value is 1, meaning by default it expects a throughput gain of X times with concurrency X.