### PR TITLE
fix(MIG-7624): ensure that wpa multiqueue scales deployments even if deployment name does not contain environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Flags:
       --sqs-short-poll-interval int                      the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)
       --wpa-default-max-disruption string                it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage. (default "100%")
       --wpa-threads int                                  wpa threadiness, number of threads to process wpa resources (default 10)
-      --environment                                      restrict wpa to scale deployment names that contain environment name (default development)
+      --environment                                      specify environment label used in metrics, logging, and feature-flag context (default development)
 
 Global Flags:
   -v, --v Level   number for the log level verbosity

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/practo/klog/v2"
@@ -397,10 +396,6 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 	var currentWorkers, availableWorkers int32
 	deploymentName := workerPodAutoScaler.Spec.DeploymentName
 	if deploymentName != "" {
-		if !strings.Contains(deploymentName, c.env) {
-			c.logger.Warn().Msgf("event ignored as deployment=%s does not match env=%s", key, c.env)
-			return nil
-		}
 		// Get the Deployment with the name specified in WorkerPodAutoScalerMultiQueue.spec
 		deployment, err := c.deploymentLister.Deployments(workerPodAutoScaler.Namespace).Get(deploymentName)
 		if errors.IsNotFound(err) {

--- a/pkg/controller/controller_sync_test.go
+++ b/pkg/controller/controller_sync_test.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	wpaapi "github.com/practo/k8s-worker-pod-autoscaler/pkg/apis/workerpodautoscalermultiqueue/v1"
+	fakecustomclientset "github.com/practo/k8s-worker-pod-autoscaler/pkg/generated/clientset/versioned/fake"
+	wpalisters "github.com/practo/k8s-worker-pod-autoscaler/pkg/generated/listers/workerpodautoscalermultiqueue/v1"
+	"github.com/practo/k8s-worker-pod-autoscaler/pkg/queue"
+	"github.com/rs/zerolog"
+	statsig "github.com/statsig-io/go-sdk"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSyncHandlerScalesDeploymentWithoutEnvNameMatch(t *testing.T) {
+	statsig.InitializeWithOptions("secret-local", &statsig.Options{LocalMode: true})
+	defer statsig.Shutdown()
+
+	testCases := []struct {
+		name           string
+		env            string
+		deploymentName string
+	}{
+		{
+			name:           "deployment name does not contain env",
+			env:            "development",
+			deploymentName: "payments-worker",
+		},
+		{
+			name:           "deployment name contains env",
+			env:            "development",
+			deploymentName: "payments-development-worker",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			namespace := "default"
+			wpaName := "test-wpa"
+			minReplicas := int32(1)
+			maxReplicas := int32(10)
+			replicas := int32(1)
+			availableReplicas := int32(2)
+
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.deploymentName,
+					Namespace: namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: availableReplicas,
+				},
+			}
+
+			wpa := &wpaapi.WorkerPodAutoScalerMultiQueue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      wpaName,
+					Namespace: namespace,
+				},
+				Spec: wpaapi.WorkerPodAutoScalerMultiQueueSpec{
+					MinReplicas:    &minReplicas,
+					MaxReplicas:    &maxReplicas,
+					DeploymentName: tc.deploymentName,
+				},
+			}
+
+			deploymentIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := deploymentIndexer.Add(deployment); err != nil {
+				t.Fatalf("failed to add deployment to indexer: %v", err)
+			}
+			wpaIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := wpaIndexer.Add(wpa); err != nil {
+				t.Fatalf("failed to add wpa to indexer: %v", err)
+			}
+
+			queues := queue.NewQueues(zerolog.Nop())
+			stopCh := make(chan struct{})
+			go queues.Sync(stopCh)
+			defer close(stopCh)
+
+			controller := &Controller{
+				ctx:                        ctx,
+				logger:                     zerolog.Nop(),
+				customclientset:            fakecustomclientset.NewSimpleClientset(wpa.DeepCopy()),
+				deploymentLister:           appslisters.NewDeploymentLister(deploymentIndexer),
+				workerPodAutoScalersLister: wpalisters.NewWorkerPodAutoScalerMultiQueueLister(wpaIndexer),
+				defaultMaxDisruption:       "100%",
+				scaleDownDelay:             0,
+				Queues:                     queues,
+				env:                        tc.env,
+			}
+
+			err := controller.syncHandler(ctx, WokerPodAutoScalerEvent{
+				key:  namespace + "/" + wpaName,
+				name: WokerPodAutoScalerEventAdd,
+			})
+			if err != nil {
+				t.Fatalf("syncHandler returned error: %v", err)
+			}
+
+			updatedWPA, err := controller.customclientset.K8sV1().
+				WorkerPodAutoScalerMultiQueues(namespace).
+				Get(ctx, wpaName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to fetch updated wpa: %v", err)
+			}
+
+			if updatedWPA.Status.CurrentReplicas != replicas {
+				t.Fatalf("expected status.currentReplicas=%d, got=%d", replicas, updatedWPA.Status.CurrentReplicas)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Issue we are facing**

Currenlty WPA ignores any WPA resource if the deployentName mentioned in the spec does not contain the environment configured. This is causing issues in autoscaling of certain shoryuken workers in the EKS cluster where the environment name (production) is not part of the deployment name.

**How is it being fixed?**
This PR removes the check which mandates that the full environment name should be part of the deployment name

